### PR TITLE
Improve performance of scoring and video creation

### DIFF
--- a/external/handlers/FsHandler.ts
+++ b/external/handlers/FsHandler.ts
@@ -9,22 +9,17 @@ export default class FsHandler {
   public imagesPath: string;
   public imagesFilename: string;
 
-  constructor() {
-    this.videoFilename = "";
-    this.outputFolder = "";
-    this.imagesPath = "";
-    this.imagesFilename = "";
-  }
-
-  async init(outputFolder: string) {
+  constructor(outputFolder: string) {
     this.outputFolder = outputFolder;
     this.videoFilename = join(this.outputFolder, Date.now() + '.webm');
     this.imagesPath = join(this.outputFolder, 'images');
     this.imagesFilename = join(this.outputFolder, 'images.txt');
+  }
+
+  async init() {
     await this.verifyPathExists(this.outputFolder);
     await this.verifyPathExists(this.imagesPath);
     await this.createEmptyFile(this.imagesFilename);
-    await this.clearImagesInPath(this.imagesPath);
   }
 
   createEmptyFile(filename: string) {
@@ -44,14 +39,8 @@ export default class FsHandler {
     return appendFile(filename, data);
   }
 
-  async clearImagesInPath(imagesPath: string) {
-    const files = await readdir(imagesPath);
-    console.log(`Removing files in ${imagesPath}`);
-    for (const file of files) {
-      const filename = join(imagesPath, file);
-      //console.log(`Removing file ${filename}`);
-      await unlink(filename);
-    }
+  getVideoFileName() : string {
+    return this.videoFilename;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "express": "^4.18.2",
         "nanoid": "^4.0.1",
         "puppeteer": "^19.6.3",
-        "puppeteer-mass-screenshots": "^1.0.15"
+        "puppeteer-mass-screenshots": "^1.0.15",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@types/airtable": "^0.10.1",
@@ -24,6 +25,7 @@
         "@types/dotenv": "^8.2.0",
         "@types/express": "^4.17.17",
         "@types/nanoid": "^3.0.0",
+        "@types/uuid": "^9.0.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.2"
       }
@@ -244,6 +246,12 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
+      "dev": true
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
@@ -2185,6 +2193,14 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -2493,6 +2509,12 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
+      "dev": true
     },
     "@types/yauzl": {
       "version": "2.10.0",
@@ -3966,6 +3988,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+    },
+    "uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "express": "^4.18.2",
     "nanoid": "^4.0.1",
     "puppeteer": "^19.6.3",
-    "puppeteer-mass-screenshots": "^1.0.15"
+    "puppeteer-mass-screenshots": "^1.0.15",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/airtable": "^0.10.1",
@@ -36,6 +37,7 @@
     "@types/dotenv": "^8.2.0",
     "@types/express": "^4.17.17",
     "@types/nanoid": "^3.0.0",
+    "@types/uuid": "^9.0.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.2"
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,7 +74,7 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
     // We will allow 5% extra time to account for anomalies
     const paddedTimeoutMs = expectedTimeoutMs * 1.05
 
-    console.log(`Note: We will wait ${paddedTimeoutMs} ms (adjusted from 15000 due to tickrate: ${tickRate})`)
+    console.log(`Note: We will wait ${paddedTimeoutMs} ms (adjusted from 30000 due to tickrate: ${tickRate})`)
 
     await page.waitForFunction("world.level.completed === true", { timeout: paddedTimeoutMs });
 
@@ -85,7 +85,7 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
     if (e instanceof TimeoutError) {
       console.log("Recording timed out!")
       const funnyMsg = "Rut roh!"
-      return { message: `${funnyMsg}  Solution not reached within 15 seconds!` }
+      return { message: `${funnyMsg}  Solution not reached within 30 seconds!` }
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,9 +41,16 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
 
   await clickToBeginCTA?.click();
 
+  console.log("We clicked, and clickToBeginCTA = " + clickToBeginCTA)
+
   // wait for selector here, too
   await page.waitForSelector(runButtonSelector);
+
+  console.log("We waited for the run button selector")
+
   const runButton = await page.$(runButtonSelector);
+
+  console.log("We got the run button!")
 
   // Wait 250ms
   console.log("Waiting 250ms")

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,8 +58,8 @@ app.post("/score", async (req, res) => {
   const tempDir = os.tmpdir()
   const uuid = uuidv4()
   const fullDir = tempDir.endsWith("/") ? tempDir + uuid : tempDir + "/" + uuid
-  console.log(`Making directory: ${tempDir}`)
-  fs.mkdtemp(tempDir, (err, folder) => {
+  console.log(`Making directory: ${fullDir}`)
+  fs.mkdtemp(fullDir, (err, folder) => {
     if (err) throw err;
     console.log(`Actual temp directory: ${folder}`)    
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,9 +55,13 @@ app.post("/score", async (req, res) => {
   let solution: Solution;
   console.log("Starting playLevel...")
   
-  fs.mkdtemp(os.tmpdir(), (err, folder) => {
+  const tempDir = os.tmpdir()
+  const uuid = uuidv4()
+  const fullDir = tempDir.endsWith("/") ? tempDir + uuid : tempDir + "/" + uuid
+  console.log(`Making directory: ${tempDir}`)
+  fs.mkdtemp(tempDir, (err, folder) => {
     if (err) throw err;
-    console.log(folder);
+    console.log(`Actual temp directory: ${folder}`)    
 
     playLevel(level, videoName, folder).then((result) => {
       res.json(result);

--- a/src/video.ts
+++ b/src/video.ts
@@ -15,7 +15,7 @@ cloudinary.config({
 
 export async function uploadVideo(filename: string) {
   try {
-    const uploadRes = await cloudinary.uploader.upload(`./${filename}`, {
+    const uploadRes = await cloudinary.uploader.upload(`${filename}`, {
       resource_type: "auto",
     });
 


### PR DESCRIPTION
This PR does a few things.

- Support for utilizing the `ticksPerSecond` and `drawModulo` query parameters that will be available when [this pr](https://github.com/hackclub/sinerider/pull/303) lands.
- Reduces the amount of overall scoring processing time for the default level (Welcome / HELLO_WORLD) from ~30 seconds to <10 seconds (300% increase).  This is done by increasing the ticks per second to 1000 (compared to a normal 30).
- Adds support for timing out scores (fails to score things when they take longer than 30s to simulate).  This also leverages the time scaling, so we will not block a server thread for 30 seconds in this case.
- Reduces the resolution and encoding settings of both the puppeteer + ffmpeg, reducing ultimate video fidelity.  This can be carefully adjusted and even modified in realtime in the service depending on load, we should do some experimentation on what levers we want to pull how much.
- Time-scales the video that we produce, which again can be controlled carefully with future experiments.  We can render videos that in realtime take 15 seconds to simulate, but show a brief synopsis in <5 sec (fast-forwarded)
- Puts image and video content into a temporary directory which is deleted afterwards, cleaning up all evidence.