### PR TITLE
Changes to support scoring and rendering good videos on the servers

### DIFF
--- a/external/index.ts
+++ b/external/index.ts
@@ -27,8 +27,8 @@ export default class PuppeteerVideoRecorder {
   }
 
   start(options = {
-    maxWidth: 1024,
-    maxHeight: 768,
+    maxWidth: 512,
+    maxHeight: 348,
     quality: 60,
     everyNthFrame: 2
   }) {

--- a/external/index.ts
+++ b/external/index.ts
@@ -27,9 +27,9 @@ export default class PuppeteerVideoRecorder {
   }
 
   start(options = {
-    maxWidth: 512,
-    maxHeight: 348,
-    quality: 70,
+    maxWidth: 1024,
+    maxHeight: 768,
+    quality: 85,
     everyNthFrame: 1
   }) {
     return this.screenshots.start(options);
@@ -49,7 +49,7 @@ export default class PuppeteerVideoRecorder {
       '-f concat',
       '-safe 0',
       `-i ${imagesFilename}`,
-      '-framerate 15',
+      '-framerate 25',
       '-hide_banner',
       videoFilename
     ].join(' ');

--- a/external/index.ts
+++ b/external/index.ts
@@ -29,8 +29,8 @@ export default class PuppeteerVideoRecorder {
   start(options = {
     maxWidth: 1024,
     maxHeight: 768,
-    quality: 85,
-    everyNthFrame: 1
+    quality: 60,
+    everyNthFrame: 2
   }) {
     return this.screenshots.start(options);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,7 +101,7 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
 
   // To avoid chopping the end of the video prematurely, we will stop the video 1 second later, adjusted
   // for our tick rate time scaling
-  const tailWaitTimeMs = 1 * (defaultTickRate / tickRate) * 1000.0
+  const tailWaitTimeMs = 1.0 * (defaultTickRate / tickRate) * 1000.0
   console.log(`Waiting ${tailWaitTimeMs}ms`)
   await new Promise(f => setTimeout(f, tailWaitTimeMs))
   console.log("Continuing...")

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
   setupPageHooks(page)
 
   console.log("Setting viewport")
-  await page.setViewport({ width: 1024, height: 768 });
+  await page.setViewport({ width: 512, height: 348 });
 
   // selectors
   const clickToBeginSelector = "#loading-string"; // will have to wait until page is fully loaded before clicking

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ let cache: { [url: string]: CacheEntry } = {};
 
 export const playLevel = async (rawLevelUrl: string, videoName: string, folder: string) => {
   const startTime = Date.now()  
-  const tickRate = 128
+  const tickRate = 256
   const drawModulo = 5
   const defaultTickRate = 30
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ let cache: { [url: string]: CacheEntry } = {};
 export const playLevel = async (rawLevelUrl: string, videoName: string, folder: string) => {
   const startTime = Date.now()  
   const tickRate = 249
-  const drawModulo = 2
+  const drawModulo = 1
   const defaultTickRate = 30
 
   const levelUrl = `${rawLevelUrl}&ticksPerSecond=${tickRate}&drawModulo=${drawModulo}`
@@ -38,7 +38,7 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
   setupPageHooks(page)
 
   console.log("Setting viewport")
-  await page.setViewport({ width: 512, height: 348 });
+  await page.setViewport({ width: 1024, height: 768 });
 
   // selectors
   const clickToBeginSelector = "#loading-string"; // will have to wait until page is fully loaded before clicking
@@ -59,7 +59,7 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
 
   await clickToBeginCTA?.click();
 
-  const wait = 2000
+  const wait = 3000
   console.log(`Waiting ${wait}ms`)
   await new Promise(f => setTimeout(f, wait))
   console.log("Continuing...")

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ let cache: { [url: string]: CacheEntry } = {};
 export const playLevel = async (rawLevelUrl: string, videoName: string, folder: string) => {
   const startTime = Date.now()  
   const tickRate = 249
-  const drawModulo = 5
+  const drawModulo = 1
   const defaultTickRate = 30
 
   const levelUrl = `${rawLevelUrl}&ticksPerSecond=${tickRate}&drawModulo=${drawModulo}`

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,7 +76,7 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
     const expectedTimeoutMs = 30.0 * (defaultTickRate / tickRate) * 1000.0
 
     // We will allow 5% extra time to account for anomalies
-    const paddedTimeoutMs = expectedTimeoutMs * 5
+    const paddedTimeoutMs = expectedTimeoutMs * 1.5
 
     console.log(`Note: We will wait ${paddedTimeoutMs} ms (adjusted from 30000 due to tickrate: ${tickRate})`)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,7 +119,7 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
   console.log("Grabbing score...")
 
   const T = await page.evaluate(
-    "parseFloat(world.level.ui.completionTime.innerText)"
+    'parseFloat(document.getElementById("completion-time").innerText)'
   );
 
   console.log("Grabbing level name...")

--- a/src/main.ts
+++ b/src/main.ts
@@ -148,7 +148,7 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
       const url = request.url();
 
       if (url.endsWith(".mp3")) {
-        request.failure();
+        await request.respond(cache["fakemp3"])
         return;
       }
 
@@ -178,12 +178,17 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
         }
 
         console.log("caching url: " + url)
-        cache[url] = {
+        const resp = {
           status: response.status(),
           headers: response.headers(),
           body: buffer,
           expires: Date.now() + (maxAge * 1000),
         };
+        cache[url] = resp
+
+        if (url.endsWith(".mp3") && !cache["fakemp3"]) {
+          cache["fakemp3"] = resp
+        }
       }
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ let cache: { [url: string]: CacheEntry } = {};
 
 export const playLevel = async (rawLevelUrl: string, videoName: string, folder: string) => {
   const startTime = Date.now()  
-  const tickRate = 1000
+  const tickRate = 90
   const drawModulo = 1
   const defaultTickRate = 30
 
@@ -125,14 +125,6 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
   console.log("Grabbing level name...")
 
   const level = await page.evaluate("world.level.name");
-
-  // console.log(expression, T);
-
-  /*
-  await page.screenshot({
-    path: "finalGame.png"
-  })
-  */
 
   console.log("Closing browser...")
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,8 +12,8 @@ let cache: { [url: string]: CacheEntry } = {};
 
 export const playLevel = async (rawLevelUrl: string, videoName: string, folder: string) => {
   const startTime = Date.now()  
-  const tickRate = 90
-  const drawModulo = 1
+  const tickRate = 128
+  const drawModulo = 5
   const defaultTickRate = 30
 
   const levelUrl = `${rawLevelUrl}&ticksPerSecond=${tickRate}&drawModulo=${drawModulo}`

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
   setupPageHooks(page)
 
   console.log("Setting viewport")
-  await page.setViewport({ width: 1, height: 1 });
+  await page.setViewport({ width: 512, height: 348 });
 
   // selectors
   const clickToBeginSelector = "#loading-string"; // will have to wait until page is fully loaded before clicking
@@ -49,9 +49,6 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
   // will be better to page.waitForSelector before doing anything else
   await page.waitForSelector(clickToBeginSelector);
   const clickToBeginCTA = await page.$(clickToBeginSelector);
-
-  console.log("Increasing viewport size")
-  await page.setViewport({ width: 512, height: 348 });
 
   console.log("Issuing click to start")
 
@@ -149,6 +146,12 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
   function setupPageHooks(page : Page) {
     page.on('request', async (request) => {
       const url = request.url();
+
+      if (url.endsWith(".mp3")) {
+        request.failure();
+        return;
+      }
+
       if (cache[url] /*&& cache[url].expires > Date.now()*/) {
         console.log("using cache for url: " + url)
         await request.respond(cache[url]);

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ let cache: { [url: string]: CacheEntry } = {};
 export const playLevel = async (rawLevelUrl: string, videoName: string, folder: string) => {
   const startTime = Date.now()  
   const tickRate = 249
-  const drawModulo = 1
+  const drawModulo = 2
   const defaultTickRate = 30
 
   const levelUrl = `${rawLevelUrl}&ticksPerSecond=${tickRate}&drawModulo=${drawModulo}`

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ let cache: { [url: string]: CacheEntry } = {};
 
 export const playLevel = async (rawLevelUrl: string, videoName: string, folder: string) => {
   const startTime = Date.now()  
-  const tickRate = 256
+  const tickRate = 249
   const drawModulo = 5
   const defaultTickRate = 30
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,12 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
   console.log("Launching puppeteer")
   const browser = await puppeteer.launch({
     headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    ignoreDefaultArgs: [
+      "--mute-audio",
+    ],
+    args: [
+      "--no-sandbox", "--disable-setuid-sandbox", "--autoplay-policy=no-user-gesture-required",
+    ]
   });
   console.log("Loading page...")
   const page = await browser.newPage();

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ let cache: { [url: string]: CacheEntry } = {};
 export const playLevel = async (rawLevelUrl: string, videoName: string, folder: string) => {
   const startTime = Date.now()  
   const tickRate = 249
-  const drawModulo = 1
+  const drawModulo = 2
   const defaultTickRate = 30
 
   const levelUrl = `${rawLevelUrl}&ticksPerSecond=${tickRate}&drawModulo=${drawModulo}`
@@ -33,7 +33,7 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
   setupPageHooks(page)
 
   console.log("Setting viewport")
-  await page.setViewport({ width: 512, height: 348 });
+  await page.setViewport({ width: 1, height: 1 });
 
   // selectors
   const clickToBeginSelector = "#loading-string"; // will have to wait until page is fully loaded before clicking
@@ -54,7 +54,9 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
 
   await clickToBeginCTA?.click();
 
-  const wait = 5000
+  await page.setViewport({ width: 512, height: 348 });
+
+  const wait = 2000
   console.log(`Waiting ${wait}ms`)
   await new Promise(f => setTimeout(f, wait))
   console.log("Continuing...")
@@ -80,8 +82,8 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
     // thus, the adjusted time (in ms) is 30 sec * defaultTickRate / tickRate * 1000 ms/sec
     const expectedTimeoutMs = 30.0 * (defaultTickRate / tickRate) * 1000.0
 
-    // We will allow 5% extra time to account for anomalies
-    const paddedTimeoutMs = expectedTimeoutMs * 1.05
+    // We will allow 10% extra time to account for anomalies
+    const paddedTimeoutMs = expectedTimeoutMs * 1.1
 
     console.log(`Note: We will wait ${paddedTimeoutMs} ms (adjusted from 30000 due to tickrate: ${tickRate})`)
 
@@ -101,7 +103,7 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
 
   // To avoid chopping the end of the video prematurely, we will stop the video 1 second later, adjusted
   // for our tick rate time scaling
-  const tailWaitTimeMs = 1.0 * (defaultTickRate / tickRate) * 1000.0
+  const tailWaitTimeMs = 1.5 * (defaultTickRate / tickRate) * 1000.0
   console.log(`Waiting ${tailWaitTimeMs}ms`)
   await new Promise(f => setTimeout(f, tailWaitTimeMs))
   console.log("Continuing...")

--- a/src/main.ts
+++ b/src/main.ts
@@ -152,7 +152,7 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
     page.on('request', async (request) => {
       const url = request.url();
 
-      if (url.endsWith(".mp3")) {
+      if (url.endsWith(".mp3") && cache["fakemp3"]) {
         await request.respond(cache["fakemp3"])
         return;
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,7 +76,7 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
     const expectedTimeoutMs = 30.0 * (defaultTickRate / tickRate) * 1000.0
 
     // We will allow 5% extra time to account for anomalies
-    const paddedTimeoutMs = expectedTimeoutMs * 1.5
+    const paddedTimeoutMs = expectedTimeoutMs * 5
 
     console.log(`Note: We will wait ${paddedTimeoutMs} ms (adjusted from 30000 due to tickrate: ${tickRate})`)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,9 +54,9 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
 
   await clickToBeginCTA?.click();
 
-  // Wait 250ms
-  console.log("Waiting 250ms")
-  await new Promise(f => setTimeout(f, 250))
+  const wait = 5000
+  console.log(`Waiting ${wait}ms`)
+  await new Promise(f => setTimeout(f, wait))
   console.log("Continuing...")
 
   // init page recorder with page

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ let cache: { [url: string]: CacheEntry } = {};
 export const playLevel = async (rawLevelUrl: string, videoName: string, folder: string) => {
   const startTime = Date.now()  
   const tickRate = 30 * 5
-  const drawModulo = 2
+  const drawModulo = 3
   const defaultTickRate = 30
 
   const levelUrl = `${rawLevelUrl}&ticksPerSecond=${tickRate}&drawModulo=${drawModulo}`

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ let cache: { [url: string]: CacheEntry } = {};
 
 export const playLevel = async (rawLevelUrl: string, videoName: string, folder: string) => {
   const startTime = Date.now()  
-  const tickRate = 249
+  const tickRate = 30 * 5
   const drawModulo = 2
   const defaultTickRate = 30
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,11 +50,12 @@ export const playLevel = async (rawLevelUrl: string, videoName: string, folder: 
   await page.waitForSelector(clickToBeginSelector);
   const clickToBeginCTA = await page.$(clickToBeginSelector);
 
+  console.log("Increasing viewport size")
+  await page.setViewport({ width: 512, height: 348 });
+
   console.log("Issuing click to start")
 
   await clickToBeginCTA?.click();
-
-  await page.setViewport({ width: 512, height: 348 });
 
   const wait = 2000
   console.log(`Waiting ${wait}ms`)


### PR DESCRIPTION
This PR does a few things, most specifically it supports generating reasonable-looking videos on the current DO server.  Here are the following changes:

- Changes the resolution/video encoding options
- Attempts to add an in-memory browser cache
- Configures puppeteer to ignore audio
- Adds more time buffer before and after starting recording to avoid undesirable clips
- Changes the method by which we detect level completion

This is an [example video](https://res.cloudinary.com/dgf5wjpcx/video/upload/v1680137364/f5gwfhqqlkh5uv5wvkjm.webm) it created.