### PR TITLE
increase padded timeout multiplier

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -86,7 +86,7 @@ export async function playLevel(rawLevelUrl: string, videoName: string, folder: 
     const expectedGameProcessingTimeMs = 30.0 * (defaultTickRate / tickRate) * 1000.0
 
     // We will allow 10% extra time to account for anomalies
-    const paddedGameProcessingTimeMs = expectedGameProcessingTimeMs * 1.1
+    const paddedGameProcessingTimeMs = expectedGameProcessingTimeMs * 1.2
 
     console.log(`Note: maximum wait time ${paddedGameProcessingTimeMs}ms with a tick rate of ${tickRate} (default: ${defaultTickRate})`)
 


### PR DESCRIPTION
With this PR (https://github.com/hackclub/sinerider/pull/457) the scoring service will throw a timeout error. I found that if we increase from 1.1 to 1.2 it works now