### PR TITLE
Use higher resolution viewport such that buttons don't overlap the start button

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ export async function playLevel(rawLevelUrl: string, videoName: string, folder: 
     setupPageHooks(page)
 
     console.log("Setting viewport")
-    await page.setViewport({ width: 512, height: 348 });
+    await page.setViewport({ width: 1024, height: 768 });
 
 
     console.log("Loading page and waiting for all assets")


### PR DESCRIPTION
The recent changes that added the twitter and reddit buttons end up overlapping the start button in the low viewport resolution we use for simulating the game in the scoring service.  Use a larger viewport (doesn't effect size of video, that's controlled separately).